### PR TITLE
Add max_loop feature to optimizer

### DIFF
--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -1,13 +1,11 @@
 use std::collections::BinaryHeap;
 use std::fmt;
 
-use crate::bounds::{BoundType, HypercubeBounds};
+use crate::bounds::HypercubeBounds;
 use crate::evaluation::PointEval;
 use crate::point;
 use crate::point::Point;
-use ordered_float::NotNan;
 
-use crate::bounds::BoundType::LowerBound;
 use crate::bounds::BoundsOverlap;
 
 #[derive(Clone)]
@@ -357,6 +355,7 @@ impl fmt::Display for Hypercube {
 mod tests {
     use super::*;
     use crate::objective_functions::rastrigin;
+    use ordered_float::NotNan;
 
     #[test]
     fn new_hypercube_1() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,9 @@ fn main() {
         upper_bound,
         neg_rastrigin,
         0.01,
-        0.01,
-        4000,
+        0.1,
+        5000,
+        100_000,
         120,
     );
 

--- a/src/objective_functions.rs
+++ b/src/objective_functions.rs
@@ -19,6 +19,16 @@ pub fn neg_rastrigin(input_point: &Point) -> f64 {
     res * -1.0
 }
 
+pub fn sphere(input_point: &Point) -> f64 {
+    let res = input_point.iter().fold(0.0, |acc, x| acc + x.powf(2.0));
+    res
+}
+
+pub fn neg_sphere(input_point: &Point) -> f64 {
+    let res = sphere(&input_point);
+    res * -1.0
+}
+
 pub fn nan_function(input_point: &Point) -> f64 {
     f64::NAN
 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -23,10 +23,13 @@ pub struct HypercubeOptimizer {
     /// desired tolerance for the difference between consective function evaluations
     tol_f: f64,
 
+    /// maximum number of optimization loops allowed
+    max_loop: u32,
+
     /// maximum number of function evaluations allowed
     max_eval: u32,
 
-    /// maximum amount of time to optimize
+    /// maximum amount of time to optimize objective function
     max_timeout: u32,
 
     /// lower bound of the search space
@@ -50,8 +53,9 @@ impl HypercubeOptimizer {
     /// * `objective_function` - a function pointer to the function being optimized
     /// * `tol_x` - once the delta between consecutive best objective function inputs falls below this
     /// value, the optimization process will terminate
-    /// * `tol_y` - once the delta between consecutive best objective function outputs falls below
+    /// * `tol_f` - once the delta between consecutive best objective function outputs falls below
     /// this value, the optimization process will terminate
+    /// * `max_loop` - the maximum number of times the optimization loop is allowed to run
     /// * `max_eval` - the maximum number of objective function evaluations the optimizer will
     /// execute
     /// * `max_timeout` - the maximum amount of time for the optimization process to run for
@@ -63,6 +67,7 @@ impl HypercubeOptimizer {
         objective_function: fn(&Point) -> f64,
         tol_x: f64,
         tol_f: f64,
+        max_loop: u32,
         max_eval: u32,
         max_timeout: u32,
         ) -> Self {
@@ -88,6 +93,7 @@ impl HypercubeOptimizer {
             hypercube,
             tol_x,
             tol_f,
+            max_loop,
             max_eval,
             max_timeout,
             lower_bound,
@@ -122,7 +128,7 @@ impl HypercubeOptimizer {
         let mut previous_best_eval = init_eval;
 
         // start optimization loop
-        for i in 0..self.max_eval {
+        for i in 0..self.max_loop {
 
             // <----- hypercube randomize ----->
 
@@ -148,7 +154,7 @@ impl HypercubeOptimizer {
             if current_best_eval.get_eval() < average_f || current_best_eval < previous_best_eval {
                 continue;
             } else {
-                println!("-------- loop {} of {} --------\n", i, self.max_eval);
+                println!("-------- loop {} of {} --------\n", i, self.max_loop);
                 println!("current best eval: {}", current_best_eval);
                 println!("previous best eval: {}", previous_best_eval);
             }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -2,7 +2,6 @@ use crate::evaluation::PointEval;
 use crate::hypercube::Hypercube;
 use crate::point::Point;
 use crate::result::HypercubeOptimizerResult;
-use ordered_float::NotNan;
 use std::collections::BinaryHeap;
 use std::f32::consts::E;
 
@@ -193,8 +192,8 @@ impl HypercubeOptimizer {
                 .scale(1.0 / self.hypercube.get_side_length());
 
             // compute normalized distance
-            let normalized_sqr_diff = (&(&current_normalized - &previous_normalized)
-                                       * &(&current_normalized - &previous_normalized));
+            let normalized_sqr_diff = &(&current_normalized - &previous_normalized)
+                                       * &(&current_normalized - &previous_normalized);
 
             let sum_normalized_sqr_diff = normalized_sqr_diff.sum();
 


### PR DESCRIPTION
The `HypercubeOptimizer::new()` method now takes in a `max_loop` argument which restricts the maximum number of optimizer loops (i.e., evaluate, shrink, and displace) before the optimizer returns.